### PR TITLE
Add some Bash resiliency

### DIFF
--- a/occultist.sh
+++ b/occultist.sh
@@ -11,7 +11,6 @@ PROGRAM='Occultist'
 PROGRAM_BINARY='occultist'
 PROGRAM_PATH=$(which occultist)
 PROGRAM_RAW_URL='https://raw.githubusercontent.com/chaos-lang/occultist/master/occultist.sh'
-BIN_PATH='/usr/local/bin/'
 LANGUAGE_NAME='the Chaos language'
 LANGUAGE_NAME_SHORT='Chaos'
 LANGUAGE_BINARY='chaos'

--- a/occultist.sh
+++ b/occultist.sh
@@ -438,7 +438,6 @@ install_requirements() {
             YUM_CMD=$(which yum)
             DNF_CMD=$(which dnf)
             PACMAN_CMD=$(which pacman)
-            PKG_CMD=$(which pkg)
             APK_CMD=$(which apk)
 
             REQUIREMENTS='git jq curl'
@@ -632,7 +631,6 @@ elif [ $1 = "register" ]; then
     SPELL_NAME=$(jq -r '.name' $JSON_FILE)
     SPELL_VERSION=$(jq -r '.version' $JSON_FILE)
     SPELL_DESCRIPTION=$(jq -r '.description' $JSON_FILE)
-    SPELL_TAGS=$(jq -r '.tags' $JSON_FILE)
     SPELL_TAGS_READABLE=$(jq -r '.tags | reduce .[1:][] as $i ("\(.[0])"; . + ", \($i)" )' $JSON_FILE)
     SPELL_TYPE=$(jq -r '.type' $JSON_FILE)
     SPELL_LICENSE=$(jq -r '.license' $JSON_FILE)

--- a/occultist.sh
+++ b/occultist.sh
@@ -126,7 +126,7 @@ install_language() {
             exit 10
         fi
     else
-        if [ ! $(mingw_is_admin) = "admin" ]; then
+        if [ ! "$(mingw_is_admin)" = "admin" ]; then
             echo -e "${RED}To install ${LANGUAGE_NAME} you need to run as administrator!${NC}"
             exit 10
         fi
@@ -201,7 +201,7 @@ uninstall_language() {
             exit 10
         fi
     else
-        if [ ! $(mingw_is_admin) = "admin" ]; then
+        if [ ! "$(mingw_is_admin)" = "admin" ]; then
             echo -e "${RED}To uninstall ${LANGUAGE_NAME} you need to run as administrator!${NC}"
             exit 10
         fi
@@ -507,7 +507,7 @@ upgrade_dependency_manager() {
             exit 16
         fi
     else
-        if [ ! $(mingw_is_admin) = "admin" ]; then
+        if [ ! "$(mingw_is_admin)" = "admin" ]; then
             echo -e "${RED}To remove ${PROGRAM} you need to run as administrator!${NC}"
             exit 10
         fi
@@ -538,7 +538,7 @@ remove_dependency_manager() {
             exit 16
         fi
     else
-        if [ ! $(mingw_is_admin) = "admin" ]; then
+        if [ ! "$(mingw_is_admin)" = "admin" ]; then
             echo -e "${RED}To upgrade ${PROGRAM} you need to run as administrator!${NC}"
             exit 10
         fi

--- a/occultist.sh
+++ b/occultist.sh
@@ -102,11 +102,12 @@ mingw_is_admin() {
 }
 
 get_latest_tag_or_default_branch() {
-    local BRANCH=$(git ls-remote --tags --refs ${1} | tail -n1 | sed 's/.*\///')
+    local BRANCH
+    $BRANCH=$(git ls-remote --tags --refs ${1} | tail -n1 | sed 's/.*\///')
     if [ -z $BRANCH ]; then
         git init &> /dev/null
-        local BRANCH=$(git remote show ${1} | grep "HEAD branch" | cut -d ":" -f 2)
-        local BRANCH="${BRANCH:1}"
+        $BRANCH=$(git remote show ${1} | grep "HEAD branch" | cut -d ":" -f 2)
+        $BRANCH="${BRANCH:1}"
     fi
     echo $BRANCH
 }

--- a/occultist.sh
+++ b/occultist.sh
@@ -545,7 +545,7 @@ remove_dependency_manager() {
     fi
 
     REMOVE_FAIL=false
-    rm $PROGRAM_PATH || REMOVE=true
+    rm $PROGRAM_PATH || REMOVE_FAIL=true
     if [ $REMOVE_FAIL = true ]; then
         echo -e "${RED}Failed to remove ${PROGRAM}!${NC}"
         exit 17

--- a/occultist.sh
+++ b/occultist.sh
@@ -102,11 +102,11 @@ mingw_is_admin() {
 
 get_latest_tag_or_default_branch() {
     local BRANCH
-    $BRANCH=$(git ls-remote --tags --refs ${1} | tail -n1 | sed 's/.*\///')
+    BRANCH=$(git ls-remote --tags --refs ${1} | tail -n1 | sed 's/.*\///')
     if [ -z $BRANCH ]; then
         git init &> /dev/null
-        $BRANCH=$(git remote show ${1} | grep "HEAD branch" | cut -d ":" -f 2)
-        $BRANCH="${BRANCH:1}"
+        BRANCH=$(git remote show ${1} | grep "HEAD branch" | cut -d ":" -f 2)
+        BRANCH="${BRANCH:1}"
     fi
     echo $BRANCH
 }


### PR DESCRIPTION
Hello,

First off, great projects. I am very excited to get my hands wet with **chaos-lang**.

I have added some Bash resiliency to the code, including removing some unused variables.

I have tested **occultist** by following various commands on [occultist.io](https://occultist.io/):
```
Upgrading occultist...
Occultist is successfully upgraded.
...
Checking for updates...
Occultist is up to date.
Installing the Chaos language to the system
Installation is successful.
...
Occultist is up to date.
Installing spell: math
The spell math:v1.1.0 is successfully installed.
...
Spell name: test-spell
Spell version: 0.0.1
Spell description: My test spell :)
    ...
/tmp $ cat occultist.json
{
  "name": "test-spell",
  "version": "0.0.1",
  "description": "My test spell :)",
  "tags": [],
  "type": "module",
  "license": "MPLv2",
  "authors": [
    {
      "name": "Noah Altunian",
      "email": "nbaltunian@gmail.com",
      "role": "maintainer"
    }
  ],
  "dependencies": {
    "math": "1.0.1"
  }
}
```

I'm looking for additional stress-testing from a reviewer. :)